### PR TITLE
Coding standards cleanup

### DIFF
--- a/src/EventSubscriber/LogEventSubscriber.php
+++ b/src/EventSubscriber/LogEventSubscriber.php
@@ -3,9 +3,7 @@
 namespace Drupal\farm_withdrawal\EventSubscriber;
 
 use Drupal\log\Event\LogEvent;
-use Drupal\quantity\Entity\QuantityInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
 
 /**
  * Copy the referenced material quantity material type meat withdrawal to the medical log.
@@ -18,7 +16,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents() {
     return [
       LogEvent::PRESAVE => 'logPresave',
-	  LogEvent::UPDATE => 'logUpdate',
+      LogEvent::UPDATE => 'logUpdate',
     ];
   }
 
@@ -30,9 +28,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   public function logPresave(LogEvent $event) {
     $log = $event->log;
-	
-	
-
 
     // Bail if not a medical log, has no quantities, or already has a meat withdrawal value.
     if ($log->bundle() !== 'medical' || $log->get('quantity')->isEmpty() || !$log->get('meat_withdrawal')->isEmpty()) {
@@ -41,7 +36,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
 
     // Find the max meat withdrawal value defined by referenced material types.
     $max_meat_withdrawal = NULL;
-    /** @var QuantityInterface $quantity */
+    /** @var \Drupal\quantity\Entity\QuantityInterface $quantity */
     foreach ($log->get('quantity')->referencedEntities() as $quantity) {
 
       // Only check material quantities with material_type reference.
@@ -57,96 +52,97 @@ class LogEventSubscriber implements EventSubscriberInterface {
       }
     }
 
-
-
     // Update the meat withdrawal value on the medical log.
-	$log->set('meat_withdrawal', $max_meat_withdrawal);
+    $log->set('meat_withdrawal', $max_meat_withdrawal);
 
   }
-  
+
+  /**
+   *
+   */
   public function logUpdate(LogEvent $event) {
     $log = $event->log;
-	$withdrawal = $log->get('meat_withdrawal');
-	
-	
-	// Bail if not a medical log, is not done or has no withdrawal or assets.
+    $withdrawal = $log->get('meat_withdrawal');
+
+    // Bail if not a medical log, is not done or has no withdrawal or assets.
     if ($log->bundle() !== 'medical' || $withdrawal->isEmpty() || $log->get('asset')->isEmpty() || $log->status->value == 'pending') {
       return;
-    } 
-	
-		//settings variables
-	$calendar_id = \Drupal::config('farm_calendar_events.settings')->get('calendar_id');
+    }
 
-    // Google api client
-	$google_api_client = \Drupal::entityTypeManager()->getStorage('google_api_client')->load(1);
-	$googleService = \Drupal::service('google_api_client.client');
-	$googleService->setGoogleApiClient($google_api_client);
-	
-	//check for expired token
-	if ($googleService->googleClient->isAccessTokenExpired()) {
-	// Refresh the access token using refresh token.
-	try {
-		$credentials = $googleService->getAccessTokenWithRefreshToken();
-		}
-		catch (Exception $e) {
-		\Drupal::logger('farm_calendar')->error($e->getMessage());
-		}
-	} else{
-	// Fetch Access Token
-		try {
-		$credentials = $googleService->googleClient->getAccessToken();
-		}
-		catch (Exception $e) {
-			\Drupal::logger('farm_calendar')->error($e->getMessage());
-		}
-	}
-			
-	$access_token = $credentials['access_token'];
-	$bearer = "Bearer $access_token";
-	
-	//Create httpClient.	
-	$client = \Drupal::httpClient();
-	
-	
-	$withdrawal_days = $log->get('meat_withdrawal')->first()->value;
-	$timestamp = $log->timestamp->value;
-	
-	$dt = new \DateTime("@$timestamp");
-	$start_date = $dt->format('Y-m-d');
-	$dt2 = $dt->modify('+'. $withdrawal_days. ' days');
-	$end_date = $dt2->format('Y-m-d');
-	
-	
-	foreach ($log->get('asset')->referencedEntities() as $asset) {
-		
-		$referenced_asset = $asset->label();
-		\Drupal::messenger()->addWarning(t("{$referenced_asset} Meat Withdrawal {$withdrawal_days} days. Ends {$end_date}"));
-		
-				//JSON
-		$json_data = json_encode(array(
-			"end" => array("date" => $end_date),
-			"start" => array("date" => $start_date),
-			"description" => "{$referenced_asset} Meat Withdrawal {$withdrawal_days} days. Ends {$end_date}",
-			"summary" => $referenced_asset,
-		));
-	
-		try {
-			//Sending POST Request with $json_data to external server
-			$request = $client->post("https://www.googleapis.com/calendar/v3/calendars/$calendar_id/events", 
-				['body' => $json_data, 
-				'headers' => 
-					['Authorization' => $bearer,],
-					['Accept' => "application/json"],
-					]);
-			//Getting Response after JSON Decode.
-			$response = json_decode($request->getBody());
-			\Drupal::messenger()->addStatus(t("Log: $referenced_asset sent to calendar"));
-		} 
-		//Catch http exceptions and log errors
-		catch (\Exception $e) {
-			\Drupal::logger('farm_calendar')->error($e->getMessage());
-			\Drupal::messenger()->addError(t("Log: $referenced_asset failed to add calendar event"));
-		}	
-	}
+    // Settings variables.
+    $calendar_id = \Drupal::config('farm_calendar_events.settings')->get('calendar_id');
+
+    // Google api client.
+    $google_api_client = \Drupal::entityTypeManager()->getStorage('google_api_client')->load(1);
+    $googleService = \Drupal::service('google_api_client.client');
+    $googleService->setGoogleApiClient($google_api_client);
+
+    // Check for expired token.
+    if ($googleService->googleClient->isAccessTokenExpired()) {
+      // Refresh the access token using refresh token.
+      try {
+        $credentials = $googleService->getAccessTokenWithRefreshToken();
+      }
+      catch (Exception $e) {
+        \Drupal::logger('farm_calendar')->error($e->getMessage());
+      }
+    }
+    else {
+      // Fetch Access Token.
+      try {
+        $credentials = $googleService->googleClient->getAccessToken();
+      }
+      catch (Exception $e) {
+        \Drupal::logger('farm_calendar')->error($e->getMessage());
+      }
+    }
+
+    $access_token = $credentials['access_token'];
+    $bearer = "Bearer $access_token";
+
+    // Create httpClient.
+    $client = \Drupal::httpClient();
+
+    $withdrawal_days = $log->get('meat_withdrawal')->first()->value;
+    $timestamp = $log->timestamp->value;
+
+    $dt = new \DateTime("@$timestamp");
+    $start_date = $dt->format('Y-m-d');
+    $dt2 = $dt->modify('+' . $withdrawal_days . ' days');
+    $end_date = $dt2->format('Y-m-d');
+
+    foreach ($log->get('asset')->referencedEntities() as $asset) {
+
+      $referenced_asset = $asset->label();
+      \Drupal::messenger()->addWarning(t("{$referenced_asset} Meat Withdrawal {$withdrawal_days} days. Ends {$end_date}"));
+
+      // JSON.
+      $json_data = json_encode([
+        "end" => ["date" => $end_date],
+        "start" => ["date" => $start_date],
+        "description" => "{$referenced_asset} Meat Withdrawal {$withdrawal_days} days. Ends {$end_date}",
+        "summary" => $referenced_asset,
+      ]);
+
+      try {
+        // Sending POST Request with $json_data to external server.
+        $request = $client->post("https://www.googleapis.com/calendar/v3/calendars/$calendar_id/events",
+        [
+          'body' => $json_data,
+          'headers' =>
+         ['Authorization' => $bearer],
+         ['Accept' => "application/json"],
+        ]);
+        // Getting Response after JSON Decode.
+        $response = json_decode($request->getBody());
+        \Drupal::messenger()->addStatus(t("Log: $referenced_asset sent to calendar"));
+      }
+      // Catch http exceptions and log errors.
+      catch (\Exception $e) {
+        \Drupal::logger('farm_calendar')->error($e->getMessage());
+        \Drupal::messenger()->addError(t("Log: $referenced_asset failed to add calendar event"));
+      }
+    }
   }
+
 }


### PR DESCRIPTION
This includes two commits. The first auto-fixes coding standards where possible via the `phpcbf` command. The second manually fixes *most* of the remaining coding standards issues that are flagged by the `phpcs` command. The only remaining issues are of this type:

`\Drupal calls should be avoided in classes, use dependency injection instead`